### PR TITLE
Improve menu visuals and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <style>
     * { box-sizing:border-box; margin:0; padding:0; }
     html,body {
-      width:100%; height:100%; font-family:'Segoe UI',sans-serif;
+      width:100%; height:100%; font-family:'Segoe UI','Roboto',sans-serif;
       overflow:hidden;
       background:linear-gradient(135deg,#1e1e1e,#111);
       color:#fff;
@@ -15,19 +15,29 @@
 
     /* Первый экран */
     #modeSelect, #difficultySelect {
-      display:flex; flex-direction:column;
-      width:100%; height:80vh; margin:10vh auto 0;
+      display:flex;
+      flex-direction:column;
+      justify-content:center;
+      align-items:center;
+      gap:20px;
+      width:100%; height:100vh;
     }
     .panel, .panelDiff {
-      flex:1; margin:5px; border-radius:8px;
+      width:90%; max-width:320px; padding:20px;
+      border-radius:12px; box-shadow:0 2px 6px rgba(0,0,0,0.5);
       display:flex; align-items:center; justify-content:center;
       cursor:pointer; font-size:32px; color:#fff;
       background:rgba(0,0,0,0.4);
       transition:background .3s, transform .3s;
     }
     .panel:hover, .panelDiff:hover { background:rgba(0,0,0,0.6); transform:scale(1.05); }
-    .modeBtn { background:#285; }
-    .rulesBtn { background:orange; color:#000; }
+    .modeBtn {
+      background:linear-gradient(135deg,#2b8,#085);
+    }
+    .rulesBtn {
+      background:linear-gradient(135deg,#f8b500,#e08f00);
+      color:#000;
+    }
     #difficultySelect { display:none; }
     .easy   { background:#4caf50; }
     .medium { background:#ff9800; }
@@ -54,8 +64,7 @@
     #board {
       visibility:hidden;
       display:grid; grid-template:repeat(5,60px)/repeat(5,60px);
-      gap:2px; margin:10px auto;
-      position:relative; left:60px;
+      gap:2px; margin:50px auto 10px;
       padding:4px; background:#111;
       border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.6);
     }
@@ -189,9 +198,9 @@
       border-radius:4px; cursor:pointer;
     }
 
-    /* Фикс для десктопа */
+    /* Мелкие правки для широких экранов */
     @media (min-width: 600px) {
-      #board { position: static; left: auto; margin:10px auto; }
+      #board { margin-top:60px; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- restyle start menu panels with gradients and centered layout
- center the board on all screens
- tweak layout spacing for wide screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aad24e76c833298126ea9339b7755