### PR TITLE
Improve visuals and center board

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,20 +61,28 @@
     }
 
     /* Поле и UI */
+    #gameArea {
+      width:100%;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+    }
     #board {
       visibility:hidden;
       display:grid; grid-template:repeat(5,60px)/repeat(5,60px);
-      gap:2px; margin:50px auto 10px;
-      padding:4px; background:#111;
-      border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.6);
+      gap:3px; margin:40px auto;
+      padding:8px; background:linear-gradient(135deg,#222,#000);
+      border:2px solid #555; border-radius:12px;
+      box-shadow:0 0 15px rgba(0,0,0,0.7);
     }
     .cell {
       width:60px; height:60px;
-      background:#333; border:1px solid #555;
+      background:linear-gradient(#444,#222);
+      border:1px solid #666;
       position:relative; transition:background .2s;
-      box-shadow:inset 0 0 5px rgba(0,0,0,0.5);
+      box-shadow:inset 0 0 6px rgba(0,0,0,0.6);
     }
-    .cell:hover { background:#555; }
+    .cell:hover { background:#666; }
     .dying-cell { background:rgba(255,0,0,0.3)!important; }
 
     #ui {
@@ -231,10 +239,11 @@
     <button id="rulesClose">Закрыть</button>
   </div>
 
-  <div id="board"></div>
+  <div id="gameArea">
+    <div id="board"></div>
 
-  <div id="ui">
-    <div id="phase"></div>
+    <div id="ui">
+      <div id="phase"></div>
     <div id="planCells">
       <div class="planCell" id="pc0"></div>
       <div class="planCell" id="pc1"></div>
@@ -254,6 +263,7 @@
       <button id="btn-del">← Удалить</button>
       <button id="btn-next">▶ Далее</button>
     </div>
+  </div>
   </div>
 
   <div id="atkOverlay"></div>


### PR DESCRIPTION
## Summary
- create `#gameArea` wrapper for board and UI
- polish board and cell styles with gradients and shadows
- wrap board and UI inside `#gameArea` to keep the field centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ab073e24c8332b6a296f0c58bef5e