### PR TITLE
Add multimedia start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,21 @@
     .medium { background:#ff9800; }
     .hard   { background:#f44336; }
 
+    #bgVideo {
+      position:fixed;
+      top:0; left:0;
+      width:100%; height:100%;
+      object-fit:cover;
+      z-index:-1;
+      filter:blur(3px) brightness(0.5);
+      transition:opacity .5s ease;
+    }
+    #bgVideo.fade { opacity:0; pointer-events:none; }
+    #title {
+      font-size:48px;
+      text-shadow:0 0 10px #0ff;
+    }
+
     /* Правила */
     #rulesOverlay {
       display:none; position:absolute;
@@ -257,7 +272,11 @@
 </head>
 <body>
 
+  <video id="bgVideo" autoplay muted loop playsinline src="https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4"></video>
+  <audio id="bgMusic" loop src="https://samplelib.com/lib/preview/mp3/sample-3s.mp3"></audio>
+
   <div id="modeSelect">
+    <h1 id="title">5×5 Arena</h1>
     <div id="btn1p" class="panel modeBtn">1 игрок</div>
     <div id="rulesBtnInitial" class="panel rulesBtn">Правила</div>
     <div id="btn2p" class="panel modeBtn">2 игрока</div>

--- a/js/core.js
+++ b/js/core.js
@@ -31,8 +31,23 @@
   const scoreA = document.getElementById('scoreA');
   const scoreB = document.getElementById('scoreB');
   const scoreReset = document.getElementById('scoreReset');
+  const bgMusic = document.getElementById('bgMusic');
+  const bgVideo = document.getElementById('bgVideo');
 
   let audioCtx;
+  let musicStarted = false;
+
+  function startMusic() {
+    if (musicStarted) return;
+    musicStarted = true;
+    bgMusic.volume = 0.5;
+    bgMusic.play().catch(() => {});
+  }
+
+  function stopMusic() {
+    bgMusic.pause();
+    bgMusic.currentTime = 0;
+  }
 
   function playSound(type) {
     if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -55,9 +70,9 @@
     updateScore();
   };
 
-  b1p.onclick = () => { single = true; ms.style.display = 'none'; ds.style.display = 'flex'; };
-  b2p.onclick = () => { single = false; ms.style.display = 'none'; startGame(); };
-  rulesInit.onclick = () => rulesOv.style.display = 'block';
+  b1p.onclick = () => { startMusic(); single = true; ms.style.display = 'none'; ds.style.display = 'flex'; };
+  b2p.onclick = () => { startMusic(); single = false; ms.style.display = 'none'; startGame(); };
+  rulesInit.onclick = () => { startMusic(); rulesOv.style.display = 'block'; };
   rulesClose.onclick = () => rulesOv.style.display = 'none';
 
   ds.querySelector('.easy').onclick   = () => { aiRand = 0.5;  ds.style.display = 'none'; startGame(); };
@@ -65,6 +80,8 @@
   ds.querySelector('.hard').onclick   = () => { aiRand = 0.1;  ds.style.display = 'none'; startGame(); };
 
   function startGame() {
+    stopMusic();
+    if (bgVideo) bgVideo.classList.add('fade');
     board.style.visibility = 'visible';
     ui.classList.add('show');
     buildBoard(); bindUI(); render(); updateUI();


### PR DESCRIPTION
## Summary
- embed background video and music
- style title and video
- start/stop music via JS and fade out video when game begins

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ac3316f7c83329f8cbf9d78db4b52