### PR TITLE
Fix online play and remove background media

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       overflow:hidden;
       background:linear-gradient(135deg,#1e1e1e,#111);
       color:#fff;
+      touch-action: manipulation;
     }
 
     /* Первый экран */
@@ -43,16 +44,6 @@
     .medium { background:#ff9800; }
     .hard   { background:#f44336; }
 
-    #bgVideo {
-      position:fixed;
-      top:0; left:0;
-      width:100%; height:100%;
-      object-fit:cover;
-      z-index:-1;
-      filter:blur(3px) brightness(0.5);
-      transition:opacity .5s ease;
-    }
-    #bgVideo.fade { opacity:0; pointer-events:none; }
     #title {
       font-size:48px;
       text-shadow:0 0 10px #0ff;
@@ -272,8 +263,6 @@
 </head>
 <body>
 
-  <video id="bgVideo" autoplay muted loop playsinline src="https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4"></video>
-  <audio id="bgMusic" loop src="https://samplelib.com/lib/preview/mp3/sample-3s.mp3"></audio>
 
   <div id="modeSelect">
     <h1 id="title">5×5 Arena</h1>

--- a/js/core.js
+++ b/js/core.js
@@ -58,23 +58,8 @@ function handleOpponentMove(move) {
   const scoreA = document.getElementById('scoreA');
   const scoreB = document.getElementById('scoreB');
   const scoreReset = document.getElementById('scoreReset');
-  const bgMusic = document.getElementById('bgMusic');
-  const bgVideo = document.getElementById('bgVideo');
 
   let audioCtx;
-  let musicStarted = false;
-
-  function startMusic() {
-    if (musicStarted) return;
-    musicStarted = true;
-    bgMusic.volume = 0.5;
-    bgMusic.play().catch(() => {});
-  }
-
-  function stopMusic() {
-    bgMusic.pause();
-    bgMusic.currentTime = 0;
-  }
 
   function playSound(type) {
     if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -97,10 +82,10 @@ function handleOpponentMove(move) {
     updateScore();
   };
 
-  b1p.onclick = () => { startMusic(); single = true; ms.style.display = 'none'; ds.style.display = 'flex'; };
-  b2p.onclick = () => { startMusic(); single = false; ms.style.display = 'none'; startGame(); };
-  bOnline.onclick = () => { startMusic(); ms.style.display = 'none'; onlineMenu.style.display = 'flex'; };
-  rulesInit.onclick = () => { startMusic(); rulesOv.style.display = 'block'; };
+  b1p.onclick = () => { single = true; ms.style.display = 'none'; ds.style.display = 'flex'; };
+  b2p.onclick = () => { single = false; ms.style.display = 'none'; startGame(); };
+  bOnline.onclick = () => { ms.style.display = 'none'; onlineMenu.style.display = 'flex'; };
+  rulesInit.onclick = () => { rulesOv.style.display = 'block'; };
   rulesClose.onclick = () => rulesOv.style.display = 'none';
 
   ds.querySelector('.easy').onclick   = () => { aiRand = 0.5;  ds.style.display = 'none'; startGame(); };
@@ -111,8 +96,6 @@ function handleOpponentMove(move) {
   onlineJoin.onclick = () => { initSocket(); joinRoom(roomInput.value.trim()); };
 
   function startGame() {
-    stopMusic();
-    if (bgVideo) bgVideo.classList.add('fade');
     board.style.visibility = 'visible';
     ui.classList.add('show');
     buildBoard(); bindUI(); render(); updateUI();
@@ -512,7 +495,7 @@ function handleOpponentMove(move) {
   }
 
   window.launchGame = startGame;
-  window.startOnlineGame = function(idx) {
+window.startOnlineGame = function(idx) {
     single = false;
     playerIndex = idx;
     ms.style.display = 'none';
@@ -520,3 +503,6 @@ function handleOpponentMove(move) {
     startGame();
   };
 })();
+
+// Prevent double-click zoom on mobile
+document.addEventListener('dblclick', e => e.preventDefault(), { passive: false });

--- a/js/socket.js
+++ b/js/socket.js
@@ -2,7 +2,8 @@ let socket;
 
 function initSocket() {
   if (socket && socket.readyState === WebSocket.OPEN) return;
-  socket = new WebSocket('ws://localhost:8080');
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  socket = new WebSocket(protocol + '//' + location.host);
   socket.onopen = () => log('✅ Соединение установлено');
   socket.onmessage = (event) => {
     const data = JSON.parse(event.data);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "server.js",
   "license": "MIT",
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "ws": "^8.17.0"
   }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,25 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
 const WebSocket = require('ws');
-const wss = new WebSocket.Server({ port: 8080 });
+
+const server = http.createServer((req, res) => {
+  const file = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(__dirname, file);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath);
+      const types = { '.js': 'text/javascript', '.html': 'text/html', '.css': 'text/css' };
+      res.writeHead(200, { 'Content-Type': types[ext] || 'application/octet-stream' });
+      res.end(data);
+    }
+  });
+});
+
+const wss = new WebSocket.Server({ server });
 
 const rooms = {};
 
@@ -62,4 +82,6 @@ wss.on('connection', ws => {
   });
 });
 
-console.log('WebSocket server running on ws://localhost:8080');
+server.listen(8080, () => {
+  console.log('Server running on http://localhost:8080');
+});


### PR DESCRIPTION
## Summary
- host static files via Node server and expose a start script
- connect WebSocket using current host
- remove background video/music and related logic
- prevent double-tap zoom

## Testing
- `npm install`
- `npm start` *(server runs)*
- `node -e "console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_685ad41dbd18833299012235168e9db5