### PR TITLE
Add round-based multiplayer sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,10 @@
       <button id="btn-next">▶ Далее</button>
     </div>
   </div>
+  <div id="onlineControls" style="margin-top:10px;display:flex;gap:6px;">
+    <button id="confirmBtn" disabled>Подтвердить</button>
+    <button id="revealBtn" style="display:none;">Показать</button>
+  </div>
   </div>
 
   <div id="atkOverlay"></div>

--- a/js/socket.js
+++ b/js/socket.js
@@ -21,6 +21,12 @@ function initSocket() {
     if (data.type === 'opponent_move') {
       handleOpponentMove(data.move);
     }
+    if (data.type === 'round_ready') {
+      onRoundReady(data.moves);
+    }
+    if (data.type === 'reveal_moves') {
+      onRevealMoves(data.moves);
+    }
     if (data.type === 'state_ok') log('✔ Ходы совпадают');
     if (data.type === 'state_mismatch') log('❌ Несовпадение состояний');
     if (data.type === 'opponent_left') log('⚠ Оппонент покинул игру');
@@ -54,6 +60,24 @@ function sendMove(move) {
     socket.send(JSON.stringify({ type: 'move', move }));
 }
 
+function submitMoves(moves) {
+  if (!isConnected) {
+    log('⛔ WebSocket ещё не подключён');
+    return;
+  }
+  if (socket && socket.readyState === WebSocket.OPEN)
+    socket.send(JSON.stringify({ type: 'submit_moves', moves }));
+}
+
+function revealMoves() {
+  if (!isConnected) {
+    log('⛔ WebSocket ещё не подключён');
+    return;
+  }
+  if (socket && socket.readyState === WebSocket.OPEN)
+    socket.send(JSON.stringify({ type: 'reveal' }));
+}
+
 function sendState(state) {
   if (socket && socket.readyState === WebSocket.OPEN)
     socket.send(JSON.stringify({ type: 'state', state }));
@@ -63,3 +87,7 @@ function log(text) {
   const el = document.getElementById('log');
   if (el) el.innerHTML += text + '<br>';
 }
+
+// Handlers that main.js should define
+function onRoundReady() {}
+function onRevealMoves() {}


### PR DESCRIPTION
## Summary
- add confirmation and reveal buttons to interface
- handle WebSocket round ready and reveal events
- collect local moves and submit in online mode
- implement server-side pending move logic

## Testing
- `node --check js/core.js`
- `node --check server.js`
- `node server.js` *(fails: Cannot find module 'ws')*

------
https://chatgpt.com/codex/tasks/task_e_685bff65e7208332abaf6ff744654271