### PR TITLE
Fix online gameplay logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,6 @@
   </div>
   <div id="onlineControls" style="margin-top:10px;display:flex;gap:6px;">
     <button id="confirmBtn" disabled>Подтвердить</button>
-    <button id="revealBtn" style="display:none;">Показать</button>
   </div>
   </div>
 

--- a/js/socket.js
+++ b/js/socket.js
@@ -3,7 +3,8 @@ let isConnected = false;
 
 function initSocket() {
   if (socket && socket.readyState === WebSocket.OPEN) return;
-  socket = new WebSocket("wss://boom-poised-sawfish.glitch.me");
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  socket = new WebSocket(proto + '//' + location.host);
   socket.onopen = () => {
     isConnected = true;
     log('✅ Соединение установлено');
@@ -21,11 +22,8 @@ function initSocket() {
     if (data.type === 'opponent_move') {
       handleOpponentMove(data.move);
     }
-    if (data.type === 'round_ready') {
-      onRoundReady(data.moves);
-    }
-    if (data.type === 'reveal_moves') {
-      onRevealMoves(data.moves);
+    if (data.type === 'start_round') {
+      onStartRound(data.moves);
     }
     if (data.type === 'state_ok') log('✔ Ходы совпадают');
     if (data.type === 'state_mismatch') log('❌ Несовпадение состояний');
@@ -69,15 +67,6 @@ function submitMoves(moves) {
     socket.send(JSON.stringify({ type: 'submit_moves', moves }));
 }
 
-function revealMoves() {
-  if (!isConnected) {
-    log('⛔ WebSocket ещё не подключён');
-    return;
-  }
-  if (socket && socket.readyState === WebSocket.OPEN)
-    socket.send(JSON.stringify({ type: 'reveal' }));
-}
-
 function sendState(state) {
   if (socket && socket.readyState === WebSocket.OPEN)
     socket.send(JSON.stringify({ type: 'state', state }));
@@ -89,5 +78,4 @@ function log(text) {
 }
 
 // Handlers that main.js should define
-function onRoundReady() {}
-function onRevealMoves() {}
+function onStartRound() {}

--- a/server.js
+++ b/server.js
@@ -69,15 +69,10 @@ wss.on('connection', ws => {
         Array.isArray(room.pendingMoves[1]) && room.pendingMoves[1].length === 5
       ) {
         room.players.forEach(p =>
-          p.send(JSON.stringify({ type: 'round_ready', moves: room.pendingMoves }))
+          p.send(JSON.stringify({ type: 'start_round', moves: room.pendingMoves }))
         );
+        room.pendingMoves = { 0: null, 1: null };
       }
-    } else if (data.type === 'reveal') {
-      const room = rooms[ws.roomId];
-      if (!room) return;
-      if (ws.playerIndex !== 0) return;
-      room.players.forEach(p => p.send(JSON.stringify({ type: 'reveal_moves', moves: room.pendingMoves })));
-      room.pendingMoves = { 0: null, 1: null };
     } else if (data.type === 'state') {
       const room = rooms[ws.roomId];
       if (!room) return;


### PR DESCRIPTION
## Summary
- connect WebSocket to the same host
- simplify online controls in HTML
- implement `start_round` handling in client and server
- let each player plan independently and step through rounds
- reset game state when starting online game

## Testing
- `npm install`
- `npm start` *(fails: module not found; after installing runs OK)*

------
https://chatgpt.com/codex/tasks/task_e_685c208d6f388332b6c768049ba049f4