### PR TITLE
Fix initial render for online mode

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -528,8 +528,8 @@ function startNewRound() {
     isOnline = true;
     ms.style.display = 'none';
     if (onlineMenu) onlineMenu.style.display = 'none';
-    resetGame();
     startGame();
+    resetGame();
     startNewRound();
     if (isOnline) document.getElementById('btn-next').style.display = 'none';
   };


### PR DESCRIPTION
## Summary
- ensure board is built before calling `resetGame` when starting online game

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c2d8bfe908332bdd57cc70bd9a3b5