### PR TITLE
Add connection status indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
     <input id="roomInput" placeholder="Код комнаты" style="padding:6px;max-width:140px;">
     <div id="onlineJoin" class="panel modeBtn">Присоединиться</div>
     <div id="roomCode"></div>
+    <div id="connectionStatus" style="font-family:'Share Tech Mono',monospace;font-size:12px;"></div>
     <div id="log" style="font-family: 'Share Tech Mono', monospace; font-size: 12px;"></div>
   </div>
 

--- a/js/socket.js
+++ b/js/socket.js
@@ -2,6 +2,14 @@ let socket;
 let isConnected = false;
 const WS_SERVER_URL = 'wss://boom-poised-sawfish.glitch.me';
 
+function updateConnectionStatus(text, color) {
+  const el = document.getElementById('connectionStatus');
+  if (el) {
+    el.textContent = text;
+    if (color) el.style.color = color;
+  }
+}
+
 function initSocket(onReady) {
   if (socket && socket.readyState === WebSocket.OPEN) {
     if (onReady) onReady();
@@ -12,10 +20,18 @@ function initSocket(onReady) {
     return;
   }
   socket = new WebSocket(WS_SERVER_URL);
+  updateConnectionStatus('Подключение...', 'yellow');
   socket.addEventListener('open', () => {
     isConnected = true;
     log('✅ Соединение установлено');
+    updateConnectionStatus('Онлайн', 'lime');
     if (onReady) onReady();
+  });
+  socket.addEventListener('close', () => {
+    isConnected = false;
+    log('⚠ Соединение прервано');
+    updateConnectionStatus('Оффлайн. Переподключение...', 'orange');
+    setTimeout(() => initSocket(), 2000);
   });
   socket.addEventListener('message', (event) => {
     const data = JSON.parse(event.data);
@@ -78,6 +94,10 @@ function log(text) {
   const el = document.getElementById('log');
   if (el) el.innerHTML += text + '<br>';
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateConnectionStatus('Оффлайн', 'orange');
+});
 
 // Handlers that main.js should define
 function onStartRound() {}


### PR DESCRIPTION
## Summary
- display connection state in online menu
- reconnect automatically when websocket closes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c2e6cde048332a26eb32bb8084a60