### PR TITLE
Fix online move confirmation

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -435,6 +435,7 @@ function startNewRound() {
       phase = 'planA'; step = 1;
       edgesCollapsed = false;
       plans = { A: [], B: [] };
+      window.plans = plans;
       usedMove = { A: new Set(), B: new Set() };
       usedAtkDirs = { A: new Set(), B: new Set() };
       usedAtk = { A: 0, B: 0 }; usedShield = { A: 0, B: 0 };
@@ -506,6 +507,7 @@ function startNewRound() {
   function resetGame() {
     round = 1; step = 1; phase = 'planA';
     plans = { A: [], B: [] };
+    window.plans = plans;
     usedMove = { A: new Set(), B: new Set() };
     usedAtkDirs = { A: new Set(), B: new Set() };
     usedAtk = { A: 0, B: 0 }; usedShield = { A: 0, B: 0 };
@@ -539,6 +541,7 @@ function startNewRound() {
 // Multiplayer helpers
 onStartRound = function(moves) {
   plans = { A: moves[0], B: moves[1] };
+  window.plans = plans;
   phase = 'execute';
   step = 1;
   const next = document.getElementById('btn-next');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "5x5-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "5x5-server",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.17.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- keep `window.plans` updated when plans object changes
- regenerate lockfile for dependencies

## Testing
- `npm install`
- `node server.js` (fails: address in use if already running)

------
https://chatgpt.com/codex/tasks/task_e_685c345829808332a3c7abb75b12fe43