### PR TITLE
Fix online mode move execution

### DIFF
--- a/js/socket.js
+++ b/js/socket.js
@@ -99,5 +99,4 @@ document.addEventListener('DOMContentLoaded', () => {
   updateConnectionStatus('Оффлайн', 'orange');
 });
 
-// Handlers that main.js should define
-function onStartRound() {}
+// Placeholder removed to allow main game script to define handlers


### PR DESCRIPTION
## Summary
- remove placeholder `onStartRound` from `socket.js` so the handler defined in `core.js` is used

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c37991a5483329c4c0fcf36a709a4