### PR TITLE
Remove duplicate clearPlan definition

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -369,9 +369,6 @@ function startNewRound() {
     });
   }
 
-  function clearPlan() {
-    document.querySelectorAll('.planMove,.planAttack,.planShield').forEach(e => e.remove());
-  }
 
   function execStep() {
     clearPlan();


### PR DESCRIPTION
## Summary
- remove the first `clearPlan` definition in `core.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c4145bbb083329fbd0c3ebdeb9b9d