### PR TITLE
Add room expiration timer

### DIFF
--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -52,6 +52,7 @@ function initSocket(onReady) {
     if (data.type === 'state_ok') log('✔ Ходы совпадают');
     if (data.type === 'state_mismatch') log('❌ Несовпадение состояний');
     if (data.type === 'opponent_left') log('⚠ Оппонент покинул игру');
+    if (data.type === 'room_expired') log('⌛ Комната закрыта из-за неактивности');
   });
 }
 


### PR DESCRIPTION
## Summary
- add server-side cleanup timer for inactive rooms
- cancel the timer if a second player rejoins
- inform players when a room expires
- show a log message when the server closes a room

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c437f73e88332bfd70fde3c3f4e3a