### PR TITLE
Fix WebSocket client URL

### DIFF
--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -1,6 +1,7 @@
 let socket;
 let isConnected = false;
-const WS_SERVER_URL = 'wss://boom-poised-sawfish.glitch.me';
+// Connect to the same host that served the page using WebSocket protocol
+const WS_SERVER_URL = location.origin.replace(/^http/, 'ws');
 
 function updateConnectionStatus(text, color) {
   const el = document.getElementById('connectionStatus');


### PR DESCRIPTION
## Summary
- use the same origin for WebSocket connections

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685c45475a54833285aa6582882f54dc