### PR TITLE
Fix confirm button state in online play

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -227,6 +227,10 @@ function startNewRound() {
       usedAtk[P]--; a.dirs.forEach(d => usedAtkDirs[P].delete(d));
     }
     updateUI(); drawPlan(P);
+    if (isOnline && plans[mySide()].length !== STEPS) {
+      const btn = document.getElementById('confirmBtn');
+      if (btn) btn.disabled = true;
+    }
   }
 
   function nextStep() {

--- a/public/js/core.js
+++ b/public/js/core.js
@@ -227,6 +227,10 @@ function startNewRound() {
       usedAtk[P]--; a.dirs.forEach(d => usedAtkDirs[P].delete(d));
     }
     updateUI(); drawPlan(P);
+    if (isOnline && plans[mySide()].length !== STEPS) {
+      const btn = document.getElementById('confirmBtn');
+      if (btn) btn.disabled = true;
+    }
   }
 
   function nextStep() {


### PR DESCRIPTION
## Summary
- disable the online confirmation button if a player deletes a move

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4d902d4c8332ba2b7a4aa53a6a04