### PR TITLE
Improve round start handling

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -38,6 +38,7 @@ function startNewRound() {
   canPlay = true;
   const btn = document.getElementById('confirmBtn');
   if (btn) btn.disabled = true;
+  console.log('Planning phase started');
 }
 
 (() => {
@@ -541,6 +542,7 @@ function startNewRound() {
   window.onStartRound = function(moves) {
     plans = { A: moves[0], B: moves[1] };
     window.plans = plans;
+    console.log('Starting execution phase with moves', moves);
     phase = 'execute';
     step = 1;
     const next = document.getElementById('btn-next');
@@ -549,6 +551,8 @@ function startNewRound() {
       next.textContent = '▶ Выполнить';
       next.disabled = false;
     }
+    const cbtn = document.getElementById('confirmBtn');
+    if (cbtn) cbtn.disabled = true;
     clearPlan();
     updateUI();
   };

--- a/js/socket.js
+++ b/js/socket.js
@@ -53,8 +53,10 @@ function initSocket(onReady) {
         clearTimeout(startRoundTimer);
         startRoundTimer = null;
       }
+      log('▶ Начало раунда');
       onStartRound(data.moves);
     }
+    if (data.type === 'error') log('⚠ ' + data.message);
     if (data.type === 'state_ok') log('✔ Ходы совпадают');
     if (data.type === 'state_mismatch') log('❌ Несовпадение состояний');
     if (data.type === 'opponent_left') log('⚠ Оппонент покинул игру');
@@ -86,6 +88,10 @@ function sendMove(move) {
 function submitMoves(moves) {
   if (!isConnected) {
     log('⛔ WebSocket ещё не подключён');
+    return;
+  }
+  if (!Array.isArray(moves) || moves.length !== 5) {
+    log('⚠ Нужно выбрать ровно 5 ходов');
     return;
   }
   if (socket && socket.readyState === WebSocket.OPEN) {

--- a/server.js
+++ b/server.js
@@ -84,8 +84,13 @@ wss.on('connection', ws => {
     } else if (data.type === 'submit_moves') {
       const room = rooms[ws.roomId];
       if (!room) return;
+      if (!Array.isArray(data.moves) || data.moves.length !== 5) {
+        ws.send(JSON.stringify({ type: 'error', message: 'Нужно отправить ровно 5 ходов' }));
+        console.log(`Player ${ws.playerIndex} sent invalid moves in room ${ws.roomId}`);
+        return;
+      }
       console.log(`Player ${ws.playerIndex} submitted moves in room ${ws.roomId}`);
-      room.pendingMoves[ws.playerIndex] = Array.isArray(data.moves) ? data.moves.slice(0, 5) : null;
+      room.pendingMoves[ws.playerIndex] = data.moves.slice(0, 5);
       if (
         Array.isArray(room.pendingMoves[0]) && room.pendingMoves[0].length === 5 &&
         Array.isArray(room.pendingMoves[1]) && room.pendingMoves[1].length === 5


### PR DESCRIPTION
## Summary
- validate move count on server before starting a round
- surface server errors to the client and log start events
- keep the confirm button disabled when a round begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d11749a4883328581d8ec51c79879