### PR TITLE
Add confirmation notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,23 @@
       border-radius:4px; cursor:pointer;
     }
 
+    /* Всплывающие сообщения */
+    #confirmToast {
+      position:absolute;
+      top:40%;
+      left:50%;
+      transform:translate(-50%,-50%);
+      background:rgba(0,0,0,0.8);
+      padding:8px 16px;
+      border-radius:6px;
+      color:#fff;
+      z-index:30;
+      pointer-events:none;
+      opacity:0;
+      transition:opacity .3s;
+    }
+    #confirmToast.show { opacity:1; }
+
     /* Мелкие правки для широких экранов */
     @media (min-width: 600px) {
       #board { margin-top:60px; }
@@ -345,6 +362,7 @@
   </div>
 
   <div id="atkOverlay"></div>
+  <div id="confirmToast"></div>
 
   <script src="js/core.js"></script>
   <script src="js/socket.js"></script>

--- a/js/socket.js
+++ b/js/socket.js
@@ -48,11 +48,17 @@ function initSocket(onReady) {
     if (data.type === 'opponent_move') {
       handleOpponentMove(data.move);
     }
+    if (data.type === 'player_confirmed') {
+      const who = data.playerIndex === 0 ? 'Игрок A' : 'Игрок B';
+      showConfirmMessage(who + ' подтвердил ходы');
+      log(who + ' подтвердил ходы');
+    }
     if (data.type === 'start_round') {
       if (startRoundTimer) {
         clearTimeout(startRoundTimer);
         startRoundTimer = null;
       }
+      log('Оба игрока подтвердили ходы, начинается просмотр');
       log('▶ Начало раунда');
       onStartRound(data.moves);
     }
@@ -113,6 +119,17 @@ function sendState(state) {
 function log(text) {
   const el = document.getElementById('log');
   if (el) el.innerHTML += text + '<br>';
+}
+
+function showConfirmMessage(text) {
+  const el = document.getElementById('confirmToast');
+  if (!el) return;
+  el.textContent = text;
+  el.classList.add('show');
+  clearTimeout(el._hideTimer);
+  el._hideTimer = setTimeout(() => {
+    el.classList.remove('show');
+  }, 2000);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/server.js
+++ b/server.js
@@ -91,11 +91,14 @@ wss.on('connection', ws => {
       }
       console.log(`Player ${ws.playerIndex} submitted moves in room ${ws.roomId}`);
       room.pendingMoves[ws.playerIndex] = data.moves.slice(0, 5);
+      room.players.forEach(p =>
+        p.send(JSON.stringify({ type: 'player_confirmed', playerIndex: ws.playerIndex }))
+      );
       if (
         Array.isArray(room.pendingMoves[0]) && room.pendingMoves[0].length === 5 &&
         Array.isArray(room.pendingMoves[1]) && room.pendingMoves[1].length === 5
       ) {
-        console.log(`Emitting start_round for room ${ws.roomId}`);
+        console.log(`Both players confirmed moves in room ${ws.roomId}, starting round`);
         room.players.forEach(p =>
           p.send(JSON.stringify({ type: 'start_round', moves: room.pendingMoves }))
         );


### PR DESCRIPTION
## Summary
- notify clients when a player confirms moves
- show disappearing notification in the game
- log when both players confirm and round starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d184f4b74833293c74ca379fe5486