### PR TITLE
Add server-side move validation

### DIFF
--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { test } = require('node:test');
+const { isValidMove } = require('./server');
+
+test('isValidMove recognises valid actions', () => {
+  assert.ok(isValidMove('up'));
+  assert.ok(isValidMove('shield'));
+  assert.ok(isValidMove({ type: 'attack', dirs: [] }));
+  assert.ok(isValidMove({ type: 'attack', dirs: ['left', 'right'] }));
+});
+
+test('isValidMove rejects invalid actions', () => {
+  assert.equal(isValidMove('jump'), false);
+  assert.equal(isValidMove({}), false);
+  assert.equal(isValidMove({ type: 'attack', dirs: 'up' }), false);
+  assert.equal(isValidMove({ type: 'attack', dirs: [123] }), false);
+  assert.equal(isValidMove({ type: 'move', dirs: ['up'] }), false);
+});


### PR DESCRIPTION
## Summary
- validate move structure in `submit_moves` handler
- expose `isValidMove` for testing
- guard server startup when imported
- add tests for move validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d239b82448332a17acdaff4a562f9