### PR TITLE
Add pretest script to run npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "main": "server.js",
   "license": "MIT",
   "scripts": {
-    "start": "node server.js",
-    "test": "node --test"
+    "pretest": "npm install",
+    "test": "node --test",
+    "start": "node server.js"
   },
   "dependencies": {
     "ws": "^8.17.0"


### PR DESCRIPTION
## Summary
- run `npm install` automatically before running tests via a `pretest` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4ced3f548332b3349e35e95f6661