### PR TITLE
Remove unused sendMove

### DIFF
--- a/js/socket.js
+++ b/js/socket.js
@@ -104,14 +104,6 @@ function joinRoom(roomId) {
   });
 }
 
-function sendMove(move) {
-  if (!isConnected) {
-    log('⛔ WebSocket ещё не подключён');
-    return;
-  }
-  if (socket && socket.readyState === WebSocket.OPEN)
-    socket.send(JSON.stringify({ type: 'move', move }));
-}
 
 function submitMoves(moves) {
   if (!isConnected) {


### PR DESCRIPTION
## Summary
- clean up socket helper by removing the unused `sendMove` function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d4fb287588332b30a43c6eadf3c12