### PR TITLE
Handle opponent leaving and add online menu reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ After you press the **Подтвердить** button your moves are sent to the
 The confirm button becomes active again so you can resend the moves. This usually means that the connection to the server was interrupted.
 
 If the page manages to reconnect, you will see **«Переподключено, повторный вход…»** and the client will automatically recreate or rejoin the last room.
+
+When your opponent leaves the room you will now see a popup with options to return to the online menu or immediately create a new room. The online menu also includes a **В меню** button which resets the room state via `resetRoomState()` and shows the main screen.

--- a/index.html
+++ b/index.html
@@ -255,6 +255,16 @@
     }
     #resultOverlay button { margin-top:10px; padding:8px 16px; }
 
+    /* Оппонент покинул игру */
+    #leaveOverlay {
+      position:absolute; top:50%; left:50%;
+      transform:translate(-50%,-50%);
+      background:#333; padding:20px;
+      border-radius:6px; text-align:center;
+      z-index:20;
+    }
+    #leaveOverlay button { margin-top:10px; padding:8px 16px; }
+
     /* Счёт */
     #scoreboard {
       position:absolute; top:6px; left:50%; transform:translateX(-50%);
@@ -313,6 +323,7 @@
     <div id="onlineCreate" class="panel modeBtn">Создать комнату</div>
     <input id="roomInput" placeholder="Код комнаты" style="padding:6px;max-width:140px;">
     <div id="onlineJoin" class="panel modeBtn">Присоединиться</div>
+    <div id="onlineBack" class="panel modeBtn">В меню</div>
     <div id="roomCode"></div>
     <div id="connectionStatus" style="font-family:'Share Tech Mono',monospace;font-size:12px;"></div>
     <div id="log" style="font-family: 'Share Tech Mono', monospace; font-size: 12px;"></div>

--- a/js/core.js
+++ b/js/core.js
@@ -67,6 +67,7 @@ function startNewRound() {
   const onlineMenu = document.getElementById('onlineMenu');
   const onlineCreate = document.getElementById('onlineCreate');
   const onlineJoin = document.getElementById('onlineJoin');
+  const onlineBack = document.getElementById('onlineBack');
   const roomInput = document.getElementById('roomInput');
   const board = document.getElementById('board');
   const ui = document.getElementById('ui');
@@ -115,6 +116,11 @@ function startNewRound() {
 
   onlineCreate.onclick = () => { createRoom(); };
   onlineJoin.onclick = () => { joinRoom(roomInput.value.trim()); };
+  onlineBack.onclick = () => {
+    if (typeof window.resetRoomState === 'function') window.resetRoomState();
+    onlineMenu.style.display = 'none';
+    ms.style.display = 'flex';
+  };
 
   function startGame() {
     board.style.visibility = 'visible';

--- a/js/socket.js
+++ b/js/socket.js
@@ -104,6 +104,7 @@ function initSocket(onReady) {
     if (data.type === 'opponent_left') {
       log('⚠ Оппонент покинул игру');
       cleanupRoom();
+      showOpponentLeftModal();
     }
     if (data.type === 'room_expired') {
       log('⌛ Комната закрыта из-за неактивности');
@@ -168,6 +169,35 @@ function showConfirmMessage(text) {
   el._hideTimer = setTimeout(() => {
     el.classList.remove('show');
   }, 2000);
+}
+
+function showOpponentLeftModal() {
+  const ov = document.createElement('div');
+  ov.id = 'leaveOverlay';
+  ov.innerHTML =
+    '<div>Оппонент покинул комнату</div>' +
+    '<div style="margin-top:10px;display:flex;gap:8px;justify-content:center;">' +
+    '<button id="leaveToMenu">В меню</button>' +
+    '<button id="leaveCreate">Создать новую</button>' +
+    '</div>';
+  document.body.append(ov);
+  document.getElementById('leaveToMenu').onclick = () => {
+    ov.remove();
+    cleanupRoom();
+    const ms = document.getElementById('modeSelect');
+    const onlineMenu = document.getElementById('onlineMenu');
+    if (ms) ms.style.display = 'flex';
+    if (onlineMenu) onlineMenu.style.display = 'none';
+  };
+  document.getElementById('leaveCreate').onclick = () => {
+    ov.remove();
+    cleanupRoom();
+    const ms = document.getElementById('modeSelect');
+    const onlineMenu = document.getElementById('onlineMenu');
+    if (ms) ms.style.display = 'none';
+    if (onlineMenu) onlineMenu.style.display = 'flex';
+    createRoom();
+  };
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- show modal when opponent leaves the room
- add a `В меню` button in the online menu
- expose resetRoomState from the button and overlay
- document new behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d8d8cfb548332aa4135e9278dac00