### PR TITLE
Add path rejection test

### DIFF
--- a/request-handler.test.js
+++ b/request-handler.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const http = require('http');
+const { test } = require('node:test');
+const { requestHandler } = require('./server');
+
+async function getStatus(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ hostname: 'localhost', port, path }, res => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode));
+    });
+    req.on('error', reject);
+  });
+}
+
+test('requestHandler rejects paths containing ..', async () => {
+  const server = http.createServer(requestHandler);
+  await new Promise(res => server.listen(0, res));
+  const { port } = server.address();
+
+  const status1 = await getStatus(port, '/..');
+  assert.equal(status1, 400);
+
+  const status2 = await getStatus(port, '/js/../server.js');
+  assert.equal(status2, 400);
+
+  await new Promise(res => server.close(res));
+});

--- a/server.js
+++ b/server.js
@@ -8,11 +8,12 @@ const jsDir = path.join(__dirname, 'js');
 const indexFile = path.join(__dirname, 'index.html');
 
 function requestHandler(req, res) {
-  const urlPath = new URL(req.url, `http://${req.headers.host}`).pathname;
-  if (urlPath.includes('..')) {
+  const rawPath = decodeURIComponent(req.url.split('?')[0]);
+  if (rawPath.includes('..')) {
     res.writeHead(400);
     return res.end('Bad request');
   }
+  const urlPath = new URL(rawPath, `http://${req.headers.host}`).pathname;
   let filePath;
   if (urlPath === '/' || urlPath === '/index.html') {
     filePath = indexFile;
@@ -186,4 +187,8 @@ if (require.main === module) {
   });
 }
 
-module.exports = { isValidMove, attachWebSocketServer };
+module.exports = {
+  isValidMove,
+  attachWebSocketServer,
+  requestHandler
+};


### PR DESCRIPTION
## Summary
- export `requestHandler`
- validate raw URL in `requestHandler`
- add tests for path traversal rejection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9d243a8883329e2818e66443f903