### PR TITLE
Handle leaving online mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ The confirm button becomes active again so you can resend the moves. This usuall
 
 If the page manages to reconnect, you will see **«Переподключено, повторный вход…»** and the client will automatically recreate or rejoin the last room.
 
-When your opponent leaves the room you will now see a popup with options to return to the online menu or immediately create a new room. The online menu also includes a **В меню** button which resets the room state via `resetRoomState()` and shows the main screen.
+When your opponent leaves the room you will now see a popup with options to return to the online menu or immediately create a new room. Leaving the online menu (including via the **В меню** button) calls `exitOnlineMode()` which sets the game back to offline mode, resets the room state with `resetRoomState()` and shows the main screen.

--- a/js/core.js
+++ b/js/core.js
@@ -118,6 +118,7 @@ function startNewRound() {
   onlineJoin.onclick = () => { joinRoom(roomInput.value.trim()); };
   onlineBack.onclick = () => {
     if (typeof window.resetRoomState === 'function') window.resetRoomState();
+    if (typeof window.exitOnlineMode === 'function') window.exitOnlineMode();
     onlineMenu.style.display = 'none';
     ms.style.display = 'flex';
   };
@@ -512,6 +513,7 @@ function startNewRound() {
     document.getElementById('resOk').onclick = () => {
       ov.remove();
       resetGame();
+      if (typeof window.exitOnlineMode === 'function') window.exitOnlineMode();
       if (typeof window.cleanupRoom === 'function') window.cleanupRoom();
     };
   }
@@ -547,6 +549,13 @@ function startNewRound() {
     startNewRound();
     if (isOnline) document.getElementById('btn-next').style.display = 'none';
   };
+
+  function exitOnlineMode() {
+    isOnline = false;
+    playerIndex = null;
+  }
+
+  window.exitOnlineMode = exitOnlineMode;
   window.plans = plans;
 
   window.onStartRound = function(moves) {

--- a/js/socket.js
+++ b/js/socket.js
@@ -196,6 +196,7 @@ function showOpponentLeftModal() {
   document.getElementById('leaveToMenu').onclick = () => {
     ov.remove();
     cleanupRoom();
+    if (typeof window.exitOnlineMode === 'function') window.exitOnlineMode();
     const ms = document.getElementById('modeSelect');
     const onlineMenu = document.getElementById('onlineMenu');
     if (ms) ms.style.display = 'flex';
@@ -204,6 +205,7 @@ function showOpponentLeftModal() {
   document.getElementById('leaveCreate').onclick = () => {
     ov.remove();
     cleanupRoom();
+    if (typeof window.exitOnlineMode === 'function') window.exitOnlineMode();
     const ms = document.getElementById('modeSelect');
     const onlineMenu = document.getElementById('onlineMenu');
     if (ms) ms.style.display = 'none';


### PR DESCRIPTION
## Summary
- add `exitOnlineMode()` to clear online flags
- call it when the game ends and when leaving online menus
- ensure online menu's **В меню** button resets offline state
- document how leaving online play resets the mode

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685dafa6622483329a9d852df7d9d9df