### PR TITLE
Add settings modal with volume control

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,15 @@
       padding:4px 8px; background:#840; color:#fff; border:none;
       border-radius:4px; cursor:pointer;
     }
+    #settingsBtn { background:#444; }
+
+    #settingsModal {
+      display:none; position:absolute; top:50%; left:50%;
+      transform:translate(-50%,-50%);
+      background:#222; padding:20px; border-radius:8px;
+      z-index:30; color:#fff;
+    }
+    #settingsModal label { display:block; margin-bottom:10px; }
 
     /* Всплывающие сообщения */
     #confirmToast {
@@ -332,6 +341,18 @@
   <div id="scoreboard">
     <span id="scoreA">0</span> : <span id="scoreB">0</span>
     <button id="scoreReset">Сбросить счёт</button>
+    <button id="settingsBtn">⚙</button>
+  </div>
+
+  <div id="settingsModal">
+    <label>Громкость: <input id="volumeSlider" type="range" min="0" max="1" step="0.01"></label>
+    <label>Язык:
+      <select id="langSelect">
+        <option value="ru">Русский</option>
+        <option value="en">English</option>
+      </select>
+    </label>
+    <button id="settingsClose">Закрыть</button>
   </div>
 
   <div id="rulesOverlay">

--- a/js/core.js
+++ b/js/core.js
@@ -3,6 +3,7 @@ let yourTurn = false;
 let localMoves = [];
 let canPlay = false;
 let isOnline = false;
+let soundVolume = 1;
 
 const mySide = () => (playerIndex === 0 ? 'A' : 'B');
 
@@ -90,7 +91,7 @@ function startNewRound() {
     osc.connect(gain); gain.connect(audioCtx.destination);
     osc.type = 'sine';
     const freq = { move: 440, attack: 660, shield: 330, win: 880 }[type] || 440;
-    osc.frequency.value = freq; gain.gain.value = 0.3;
+    osc.frequency.value = freq; gain.gain.value = 0.3 * soundVolume;
     osc.start(); osc.stop(audioCtx.currentTime + 0.15);
   }
 
@@ -586,6 +587,24 @@ document.addEventListener('DOMContentLoaded', () => {
     canPlay = false;
     cbtn.disabled = true;
   };
+
+  const settingsBtn = document.getElementById('settingsBtn');
+  const settingsModal = document.getElementById('settingsModal');
+  const settingsClose = document.getElementById('settingsClose');
+  const volumeSlider = document.getElementById('volumeSlider');
+
+  if (settingsBtn && settingsModal) {
+    settingsBtn.onclick = () => { settingsModal.style.display = 'block'; };
+  }
+  if (settingsClose && settingsModal) {
+    settingsClose.onclick = () => { settingsModal.style.display = 'none'; };
+  }
+  if (volumeSlider) {
+    volumeSlider.value = soundVolume;
+    volumeSlider.oninput = () => {
+      soundVolume = parseFloat(volumeSlider.value);
+    };
+  }
 });
 
 // Prevent double-click zoom on mobile


### PR DESCRIPTION
## Summary
- add Settings button next to the scoreboard
- implement hidden modal for volume and language options
- allow sound volume adjustment via global variable
- update playSound to respect the new volume level
- hook up JS to open and close the settings dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e62856fcc833297634743890643da