### PR TITLE
Add localStorage support for volume and language settings

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -3,7 +3,8 @@ let yourTurn = false;
 let localMoves = [];
 let canPlay = false;
 let isOnline = false;
-let soundVolume = 1;
+let soundVolume = parseFloat(localStorage.getItem('volume'));
+if (isNaN(soundVolume)) soundVolume = 1;
 
 const mySide = () => (playerIndex === 0 ? 'A' : 'B');
 
@@ -827,12 +828,16 @@ document.addEventListener('DOMContentLoaded', () => {
     volumeSlider.value = soundVolume;
     volumeSlider.oninput = () => {
       soundVolume = parseFloat(volumeSlider.value);
+      localStorage.setItem('volume', soundVolume);
     };
   }
   if (langSelect) {
     langSelect.value = window.i18n ? window.i18n.lang : 'en';
     langSelect.onchange = () => {
-      if (window.i18n) window.i18n.setLang(langSelect.value);
+      if (window.i18n) {
+        window.i18n.setLang(langSelect.value);
+        localStorage.setItem('language', langSelect.value);
+      }
     };
   }
   if (menuBtn) menuBtn.onclick = () => returnToMenu();

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -192,6 +192,10 @@
   };
 
   let currentLang = 'en';
+  const storedLang = localStorage.getItem('language');
+  if (storedLang && translations[storedLang]) {
+    currentLang = storedLang;
+  }
 
   function t(key) {
     return translations[currentLang][key] || translations.en[key] || key;


### PR DESCRIPTION
## Summary
- read preferred language from localStorage when loading `i18n.js`
- read saved volume level when `core.js` loads
- persist settings when the slider or selector is changed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea2c11e7c8332b8139a9cb9292d8d