### PR TITLE
Add simple tutorial overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,6 +297,19 @@
       color:#fff !important; border:none !important;
     }
 
+    /* Tutorial overlay */
+    #tutorialOverlay {
+      display:none; position:absolute; top:0; left:0;
+      width:100%; height:100%;
+      background:rgba(0,0,0,0.8);
+      flex-direction:column;
+      justify-content:center; align-items:center;
+      text-align:center; padding:20px;
+      z-index:40;
+    }
+    #tutorialOverlay.show { display:flex; }
+    #tutorialOverlay button { margin-top:20px; }
+
     /* Оппонент покинул игру */
     #leaveOverlay {
       position:absolute; top:50%; left:50%;
@@ -481,6 +494,10 @@
   <div id="atkOverlay"></div>
   <div id="confirmToast"></div>
   <div id="replayOverlay"><button id="replayClose" data-i18n="close">Close</button></div>
+  <div id="tutorialOverlay">
+    <div id="tutorialContent"></div>
+    <button id="tutorialNext" data-i18n="nextBtn">Next</button>
+  </div>
 
   <script src="js/i18n.js"></script>
   <script src="js/core.js"></script>

--- a/js/core.js
+++ b/js/core.js
@@ -846,6 +846,25 @@ document.addEventListener('DOMContentLoaded', () => {
   document.body.addEventListener('click', e => {
     if (e.target.tagName === 'BUTTON') playSound('ui');
   });
+
+  const tutOv = document.getElementById('tutorialOverlay');
+  const tutCont = document.getElementById('tutorialContent');
+  const tutNext = document.getElementById('tutorialNext');
+  if (tutOv && tutCont && tutNext && !localStorage.getItem('tutorialDone')) {
+    const steps = [t('tutorial1'), t('tutorial2'), t('tutorial3')];
+    let idx = 0;
+    tutCont.textContent = steps[0];
+    tutOv.classList.add('show');
+    tutNext.onclick = () => {
+      idx++;
+      if (idx < steps.length) {
+        tutCont.textContent = steps[idx];
+      } else {
+        tutOv.classList.remove('show');
+        localStorage.setItem('tutorialDone', '1');
+      }
+    };
+  }
 });
 
 // Prevent double-click zoom on mobile

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -62,6 +62,9 @@
       ,rule6: 'A player dies if struck by an attack or when stepping on collapsed cells.'
       ,rule7: 'After three rounds the outer ring collapses leaving a 3\u00d73 arena.'
       ,rule8: 'If there is no winner after the last round, the match ends in a draw.'
+      ,tutorial1: 'Welcome! Use arrows or buttons to move.'
+      ,tutorial2: 'Plan five actions including one attack and one shield.'
+      ,tutorial3: 'Press Confirm to execute and win.'
     },
     ru: {
       singlePlayer: '1 игрок',
@@ -125,6 +128,9 @@
       rule6: 'Игрок погибает от атаки или наступив на провалившуюся клетку.',
       rule7: 'После трёх раундов края поля разрушаются, остаётся зона 3\u00d73.',
       rule8: 'Если победителя нет после финала, объявляется ничья.'
+      ,tutorial1: 'Добро пожаловать! Используйте стрелки или кнопки для движения.'
+      ,tutorial2: 'Запланируйте пять действий, включая атаку и щит.'
+      ,tutorial3: 'Нажмите \u00abПодтвердить\u00bb, чтобы начать раунд.'
     },
     uk: {
       singlePlayer: '1 гравець',
@@ -188,6 +194,9 @@
       rule6: 'Гравець гине від атаки або ступивши на зруйновану клітину.',
       rule7: 'Після трьох раундів зовнішнє кільце зникає, залишається арена 3\u00d73.',
       rule8: 'Якщо переможця немає після фінального раунду, оголошується нічия.'
+      ,tutorial1: 'Ласкаво просимо! Використовуйте стрілки або кнопки для руху.'
+      ,tutorial2: 'Заплануйте п\u2019ять дій, включаючи атаку та щит.'
+      ,tutorial3: 'Натисніть \u00abПідтвердити\u00bb, щоб розпочати раунд.'
     }
   };
 


### PR DESCRIPTION
## Summary
- add tutorial overlay markup and styles
- provide i18n strings for tutorial text
- show tutorial messages on first load only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea38647388332962d2c15b3f6c925