### PR TITLE
Add PWA manifest and favicon support

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>5×5 PvP Game</title>
   <link rel="icon" type="image/png" href="assets/icon.png"/>
   <link rel="apple-touch-icon" href="assets/icon.png"/>
+  <link rel="manifest" href="manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
   <style>
     * { box-sizing:border-box; margin:0; padding:0; }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "5×5 PvP Game",
+  "short_name": "5x5",
+  "icons": [
+    {
+      "src": "assets/icon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000"
+}

--- a/server.js
+++ b/server.js
@@ -37,7 +37,8 @@ function requestHandler(req, res) {
         '.html': 'text/html',
         '.css': 'text/css',
         '.png': 'image/png',
-        '.ico': 'image/x-icon'
+        '.ico': 'image/x-icon',
+        '.json': 'application/json'
       };
       res.writeHead(200, { 'Content-Type': types[ext] || 'application/octet-stream' });
       res.end(data);


### PR DESCRIPTION
## Summary
- include manifest and theme color in `index.html`
- serve JSON files with correct MIME type
- add `manifest.json` for PWA support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea952e08483328fd88b0ef8b83c06