### PR TITLE
Improve replay overlay and animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,13 +292,15 @@
     /* Overlay for replay mode */
     #replayOverlay {
       display:none; position:absolute; top:0; left:0;
-      width:100%; height:100%; background:rgba(0,0,0,0.8);
-      justify-content:center; align-items:center; z-index:30;
+      width:100%; height:100%; background:rgba(0,0,0,0.2);
+      pointer-events:none; z-index:30;
     }
-    #replayOverlay.show { display:flex; }
+    #replayOverlay.show { display:block; }
     #replayOverlay button {
+      position:absolute; top:10px; right:10px;
       padding:8px 16px; background:#444;
       color:#fff !important; border:none !important;
+      pointer-events:auto;
     }
 
     /* Tutorial overlay */


### PR DESCRIPTION
## Summary
- lighten and reposition the replay overlay
- make only the close button capture pointer events
- animate attacks and shields during replays

## Testing
- `npm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ebb28785c8332bc4ee0cb5e515d26