### PR TITLE
Add replay speed control

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,27 @@
       color:#fff !important; border:none !important;
       pointer-events:auto;
     }
+    .speedControl {
+      position:absolute;
+      bottom:20px;
+      left:50%;
+      transform:translateX(-50%);
+      display:flex;
+      align-items:center;
+      gap:8px;
+      background:rgba(0,0,0,0.7);
+      padding:6px 12px;
+      border-radius:6px;
+      pointer-events:auto;
+    }
+    #replaySpeed {
+      width:120px;
+      accent-color:#0ff;
+    }
+    #replaySpeedLabel {
+      min-width:24px;
+      text-align:center;
+    }
 
     /* Tutorial overlay */
     #tutorialOverlay {
@@ -541,7 +562,13 @@
 
   <div id="atkOverlay"></div>
   <div id="confirmToast"></div>
-  <div id="replayOverlay"><button id="replayClose" data-i18n="close" data-sound="nav">Close</button></div>
+  <div id="replayOverlay">
+    <button id="replayClose" data-i18n="close" data-sound="nav">Close</button>
+    <div class="speedControl">
+      <input id="replaySpeed" type="range" min="0" max="5" step="0.5" value="1">
+      <span id="replaySpeedLabel">1x</span>
+    </div>
+  </div>
   <div id="tutorialOverlay">
     <div id="tutorialContent"></div>
     <button id="tutorialNext" data-i18n="nextBtn" data-sound="nav">Next</button>

--- a/js/core.js
+++ b/js/core.js
@@ -5,6 +5,7 @@ let canPlay = false;
 let isOnline = false;
 let soundVolume = parseFloat(localStorage.getItem('volume'));
 if (isNaN(soundVolume)) soundVolume = 1;
+let replaySpeed = 1;
 
 const mySide = () => (playerIndex === 0 ? 'A' : 'B');
 
@@ -742,6 +743,7 @@ function startNewRound() {
     let i = 0;
     function play() {
       if (!isReplaying) return;
+      if (replaySpeed === 0) { setTimeout(play, 100); return; }
       if (i >= frames.length) { endReplay(); return; }
       const f = frames[i++];
       const st = f.state;
@@ -749,7 +751,7 @@ function startNewRound() {
       units = { A: { ...st.units.A }, B: { ...st.units.B } };
       render(); updateUI();
       if (f.actions) animateReplayActions(f.actions);
-      setTimeout(play, 700);
+      setTimeout(play, 700 / (replaySpeed || 0.1));
     }
     play();
   }
@@ -914,6 +916,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const langSelect = document.getElementById('langSelect');
   const menuBtn = document.getElementById('menuBtn');
   const replayClose = document.getElementById('replayClose');
+  const replaySpeedSlider = document.getElementById('replaySpeed');
+  const replaySpeedLabel = document.getElementById('replaySpeedLabel');
 
   if (settingsBtn && settingsModal) {
     settingsBtn.onclick = () => { settingsModal.style.display = 'block'; };
@@ -939,6 +943,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (menuBtn) menuBtn.onclick = () => returnToMenu();
   if (replayClose) replayClose.onclick = () => endReplay();
+  if (replaySpeedSlider && replaySpeedLabel) {
+    replaySpeedSlider.value = replaySpeed;
+    replaySpeedLabel.textContent = replaySpeed + 'x';
+    replaySpeedSlider.oninput = () => {
+      replaySpeed = parseFloat(replaySpeedSlider.value);
+      replaySpeedLabel.textContent = replaySpeed + 'x';
+    };
+  }
 
   document.body.addEventListener("click", e => {
     playSound(e.target.dataset.sound || "ui");


### PR DESCRIPTION
## Summary
- add speed slider to replay overlay with styling
- track global `replaySpeed`
- adjust replay timing and allow pausing when speed is zero
- update event listeners to handle speed changes

## Testing
- `npm test` *(fails: layout-test.js error)*

------
https://chatgpt.com/codex/tasks/task_e_685ed388a3b08332967ba7d8d6feb5a7