### PR TITLE
Handle invalid URL encoding

### DIFF
--- a/request-handler.test.js
+++ b/request-handler.test.js
@@ -26,3 +26,14 @@ test('requestHandler rejects paths containing ..', async () => {
 
   await new Promise(res => server.close(res));
 });
+
+test('requestHandler returns 400 for malformed percent-encoding', async () => {
+  const server = http.createServer(requestHandler);
+  await new Promise(res => server.listen(0, res));
+  const { port } = server.address();
+
+  const status = await getStatus(port, '/%GG');
+  assert.equal(status, 400);
+
+  await new Promise(res => server.close(res));
+});

--- a/server.js
+++ b/server.js
@@ -8,7 +8,13 @@ const jsDir = path.join(__dirname, 'js');
 const indexFile = path.join(__dirname, 'index.html');
 
 function requestHandler(req, res) {
-  const rawPath = decodeURIComponent(req.url.split('?')[0]);
+  let rawPath;
+  try {
+    rawPath = decodeURIComponent(req.url.split('?')[0]);
+  } catch (e) {
+    res.writeHead(400);
+    return res.end('Bad request');
+  }
   if (rawPath.includes('..')) {
     res.writeHead(400);
     return res.end('Bad request');


### PR DESCRIPTION
## Summary
- guard `decodeURIComponent` in request handler
- return 400 when the path cannot be decoded
- test that malformed percent-encoding yields 400

## Testing
- `npm test` *(fails: layout-test.js test failure)*

------
https://chatgpt.com/codex/tasks/task_e_685ef7f586e083329a853277c13340e8