### PR TITLE
Install Playwright on setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,9 @@ A simple WebSocket-based 5×5 PvP game.
 
 ### Running tests
 
-After installing dependencies with `npm install`, you must install Playwright's
-browsers so the layout test in `layout-test.js` can run correctly:
-
-```bash
-npx playwright install
-```
-
-With the browsers installed, the test suite can be run using:
+After running `npm install`, Playwright's browsers are automatically installed
+via the `postinstall` script. Once dependencies are installed, the test suite
+can be run using:
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "pretest": "npm install",
+    "postinstall": "npx playwright install",
     "test": "node --test",
     "start": "node server.js"
   },


### PR DESCRIPTION
## Summary
- automate Playwright browser install via `postinstall`
- update the README instructions for running the tests

## Testing
- `npm install`
- `npm test` *(fails: Missing libraries for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685efda77644833292544c2a02a5fc2d