### PR TITLE
Allow configurable websocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,24 @@ A simple WebSocket-based 5×5 PvP game.
    node server.js
    ```
 
+
    The game will be served on [https://boom-poised-sawfish.glitch.me](https://boom-poised-sawfish.glitch.me).
+
+### Configuring the WebSocket server
+
+The client connects to the hosted WebSocket server above by default. For local
+development you can point the client at your own server in two ways:
+
+1. Define `WS_SERVER_URL` before including `js/socket.js`:
+
+   ```html
+   <script>window.WS_SERVER_URL = 'ws://localhost:8080';</script>
+   <script src="js/socket.js"></script>
+   ```
+
+2. Pass a `ws` query parameter when opening the page:
+
+   `http://localhost:8080/?ws=ws://localhost:8080`
 
 ### Running tests
 

--- a/js/socket.js
+++ b/js/socket.js
@@ -6,8 +6,18 @@ let startRoundTimer = null;
 let lastRoomId = null;
 let wasCreator = false;
 let intentionalClose = false;
-// Connect to the dedicated WebSocket server
-const WS_SERVER_URL = 'wss://boom-poised-sawfish.glitch.me';
+// Connect to the dedicated WebSocket server by default. The URL can be
+// overridden by setting `window.WS_SERVER_URL` before this script runs or by
+// providing a `ws` query parameter in the page URL.
+let WS_SERVER_URL = 'wss://boom-poised-sawfish.glitch.me';
+if (typeof window !== 'undefined') {
+  const params = new URLSearchParams(window.location.search);
+  if (window.WS_SERVER_URL) {
+    WS_SERVER_URL = window.WS_SERVER_URL;
+  } else if (params.get('ws')) {
+    WS_SERVER_URL = params.get('ws');
+  }
+}
 
 function updateConnectionStatus(text, color) {
   const el = document.getElementById('connectionStatus');

--- a/layout-test.js
+++ b/layout-test.js
@@ -11,7 +11,7 @@ const { spawn } = require('child_process');
   for (const width of widths) {
     const context = await browser.newContext({ viewport: { width, height: 640 } });
     const page = await context.newPage();
-    await page.goto('http://localhost:8080');
+    await page.goto('http://localhost:8080/?ws=ws://localhost:8080');
     const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
     if (bodyWidth > width) {
       console.error(`Layout overflow at width ${width}: body ${bodyWidth}`);


### PR DESCRIPTION
## Summary
- allow overriding WS_SERVER_URL via window variable or `ws` query param
- document how to set a custom WebSocket server
- make layout test point to local WebSocket server

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f01f42f688332ae44f8eecd0cfc19