### PR TITLE
Implement replay speed buttons and pause toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,13 +345,17 @@
       border-radius:6px;
       pointer-events:auto;
     }
-    #replaySpeed {
-      width:120px;
-      accent-color:#0ff;
+    .speedBtn,
+    #replayPause {
+      background:#444;
+      color:#fff;
+      border:none;
+      padding:4px 8px;
+      cursor:pointer;
     }
-    #replaySpeedLabel {
-      min-width:24px;
-      text-align:center;
+    .speedBtn.active {
+      background:#0ff;
+      color:#000;
     }
 
     /* Tutorial overlay */
@@ -584,8 +588,12 @@
     <button id="saveReplay" data-i18n="saveVideo" data-sound="nav" style="right:90px;top:10px;position:absolute;">Save</button>
     <input id="replaySeek" type="range" min="0" max="0" step="1" value="0" style="position:absolute;left:10px;right:10px;bottom:60px;pointer-events:auto;">
     <div class="speedControl">
-      <input id="replaySpeed" type="range" min="0" max="5" step="0.5" value="1">
-      <span id="replaySpeedLabel">1x</span>
+      <button class="speedBtn" data-speed="1">1x</button>
+      <button class="speedBtn" data-speed="2">2x</button>
+      <button class="speedBtn" data-speed="3">3x</button>
+      <button class="speedBtn" data-speed="4">4x</button>
+      <button class="speedBtn" data-speed="5">5x</button>
+      <button id="replayPause">❚❚</button>
     </div>
   </div>
   <div id="tutorialOverlay">

--- a/js/core.js
+++ b/js/core.js
@@ -9,6 +9,7 @@ let replaySpeed = 1;
 let replayFrames = [];
 let replayIndex = 0;
 let replayTimer = null;
+let replayPaused = false;
 let recorder = null;
 let recordedChunks = [];
 
@@ -735,6 +736,9 @@ function startNewRound() {
     isReplaying = true;
     const ov = document.getElementById('replayOverlay');
     if (ov) ov.classList.add('show');
+    replayPaused = false;
+    const pauseBtn = document.getElementById('replayPause');
+    if (pauseBtn) pauseBtn.textContent = '❚❚';
     resetGame();
     replayFrames = [];
     replayHistory.forEach(r => {
@@ -754,7 +758,7 @@ function startNewRound() {
     }
     function play() {
       if (!isReplaying) return;
-      if (replaySpeed === 0) { replayTimer = setTimeout(play, 100); return; }
+      if (replayPaused) { replayTimer = setTimeout(play, 100); return; }
       if (replayIndex >= replayFrames.length) { endReplay(); return; }
       const f = replayFrames[replayIndex++];
       renderReplayFrame(f);
@@ -982,8 +986,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const langSelect = document.getElementById('langSelect');
   const menuBtn = document.getElementById('menuBtn');
   const replayClose = document.getElementById('replayClose');
-  const replaySpeedSlider = document.getElementById('replaySpeed');
-  const replaySpeedLabel = document.getElementById('replaySpeedLabel');
+  const speedBtns = document.querySelectorAll('.speedBtn');
+  const replayPauseBtn = document.getElementById('replayPause');
   const replayBtn = document.getElementById('replayBtn');
   const saveReplayBtn = document.getElementById('saveReplay');
   const replaySeek = document.getElementById('replaySeek');
@@ -1018,12 +1022,20 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (saveReplayBtn) saveReplayBtn.onclick = () => saveReplayVideo();
   if (replaySeek) replaySeek.oninput = () => seekReplay(parseInt(replaySeek.value));
-  if (replaySpeedSlider && replaySpeedLabel) {
-    replaySpeedSlider.value = replaySpeed;
-    replaySpeedLabel.textContent = replaySpeed + 'x';
-    replaySpeedSlider.oninput = () => {
-      replaySpeed = parseFloat(replaySpeedSlider.value);
-      replaySpeedLabel.textContent = replaySpeed + 'x';
+  if (speedBtns.length) {
+    speedBtns.forEach(btn => {
+      if (parseFloat(btn.dataset.speed) === replaySpeed) btn.classList.add('active');
+      btn.onclick = () => {
+        replaySpeed = parseFloat(btn.dataset.speed);
+        speedBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+      };
+    });
+  }
+  if (replayPauseBtn) {
+    replayPauseBtn.onclick = () => {
+      replayPaused = !replayPaused;
+      replayPauseBtn.textContent = replayPaused ? '▶' : '❚❚';
     };
   }
 


### PR DESCRIPTION
## Summary
- replace slider with speed buttons and pause toggle in `index.html`
- highlight the active speed button via CSS
- update replay logic in `js/core.js` to support buttons and pause functionality

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f0f0f22e48332bf8e7907f173b42d