### PR TITLE
Refactor language selector into custom dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,6 +427,28 @@
       background-size:10px 6px;
     }
 
+    .dropdown { position:relative; display:inline-block; }
+    .dropdown-display {
+      padding:6px 24px 6px 8px;
+      background:#222; border:1px solid #0ff; color:#0ff;
+      border-radius:4px; cursor:pointer;
+      position:relative;
+    }
+    .dropdown-display::after {
+      content:''; position:absolute; right:8px; top:50%; width:10px; height:6px;
+      background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath fill='%230ff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E") no-repeat;
+      background-size:10px 6px; transform:translateY(-50%); pointer-events:none;
+    }
+    .dropdown.open .dropdown-display::after { transform:translateY(-50%) rotate(180deg); }
+    .dropdown-list {
+      display:none; position:absolute; top:100%; left:0; min-width:100%;
+      background:#222; border:1px solid #0ff; border-radius:4px; margin-top:2px;
+      z-index:40;
+    }
+    .dropdown.open .dropdown-list { display:block; }
+    .dropdown-option { padding:6px 8px; cursor:pointer; color:#0ff; }
+    .dropdown-option:hover { background:#444; }
+
     /* Всплывающие сообщения */
     #confirmToast {
       position:absolute;
@@ -527,11 +549,14 @@
   <div id="settingsModal">
     <label><span data-i18n="volume">Громкость:</span> <input id="volumeSlider" type="range" min="0" max="1" step="0.01"></label>
     <label><span data-i18n="language">Язык:</span>
-      <select id="langSelect">
-        <option value="en">English</option>
-        <option value="ru">Русский</option>
-        <option value="uk">Українська</option>
-      </select>
+      <div id="langSelect" class="dropdown" data-value="en">
+        <div class="dropdown-display"></div>
+        <div class="dropdown-list">
+          <div class="dropdown-option" data-value="en">English</div>
+          <div class="dropdown-option" data-value="ru">Русский</div>
+          <div class="dropdown-option" data-value="uk">Українська</div>
+        </div>
+      </div>
     </label>
     <button id="settingsClose" data-i18n="close" data-sound="nav">Закрыть</button>
   </div>
@@ -602,6 +627,7 @@
   </div>
 
   <script src="js/i18n.js"></script>
+  <script src="js/dropdown.js"></script>
   <script src="js/core.js"></script>
   <script src="js/socket.js"></script>
   <script>

--- a/js/core.js
+++ b/js/core.js
@@ -1006,13 +1006,17 @@ document.addEventListener('DOMContentLoaded', () => {
     };
   }
   if (langSelect) {
-    langSelect.value = window.i18n ? window.i18n.lang : 'en';
-    langSelect.onchange = () => {
+    langSelect.dataset.value = window.i18n ? window.i18n.lang : 'en';
+  }
+  if (typeof setupDropdowns === 'function') setupDropdowns();
+  if (langSelect) {
+    langSelect.addEventListener('change', () => {
+      const val = langSelect.dataset.value;
       if (window.i18n) {
-        window.i18n.setLang(langSelect.value);
-        localStorage.setItem('language', langSelect.value);
+        window.i18n.setLang(val);
+        localStorage.setItem('language', val);
       }
-    };
+    });
   }
   if (menuBtn) menuBtn.onclick = () => returnToMenu();
   if (replayClose) replayClose.onclick = () => endReplay();

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -1,0 +1,40 @@
+(function(){
+  function init(dropdown, initial){
+    const display = dropdown.querySelector('.dropdown-display');
+    const list = dropdown.querySelector('.dropdown-list');
+    const options = Array.from(dropdown.querySelectorAll('.dropdown-option'));
+    const set = (val,text)=>{
+      dropdown.dataset.value = val;
+      if(display) display.textContent = text;
+    };
+    display.addEventListener('click',e=>{
+      e.stopPropagation();
+      dropdown.classList.toggle('open');
+    });
+    options.forEach(opt=>{
+      opt.addEventListener('click',e=>{
+        e.stopPropagation();
+        set(opt.dataset.value,opt.textContent);
+        dropdown.classList.remove('open');
+        dropdown.dispatchEvent(new Event('change'));
+      });
+    });
+    if(initial){
+      const o=options.find(op=>op.dataset.value===initial);
+      if(o) set(o.dataset.value,o.textContent);
+    } else if(options[0]) {
+      set(options[0].dataset.value,options[0].textContent);
+    }
+  }
+  function closeAll(e){
+    document.querySelectorAll('.dropdown.open').forEach(d=>{
+      if(!d.contains(e.target)) d.classList.remove('open');
+    });
+  }
+  window.setupDropdowns=function(){
+    document.querySelectorAll('.dropdown').forEach(d=>{
+      init(d,d.dataset.value);
+    });
+    document.addEventListener('click',closeAll);
+  };
+})();


### PR DESCRIPTION
## Summary
- create generic dropdown component
- use dropdown component for language selection
- load dropdown script before core logic
- hook language changes through dropdown

## Testing
- `npm test` *(fails: Host system is missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f12b40d9c8332ae9e5c4e4cd83e4b