### PR TITLE
Improve attack overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,24 +285,38 @@
       visibility:hidden;
       position:absolute; top:50%; left:50%;
       transform:translate(-50%,-50%);
-      background:rgba(0,0,0,0.8); padding:10px;
-      display:flex; flex-wrap:wrap; gap:6px;
-      border-radius:6px; z-index:10;
+      background:rgba(0,0,0,0.8); padding:20px;
+      display:grid; gap:8px;
+      grid-template-columns:repeat(3, 70px);
+      grid-template-rows:repeat(3, 70px) auto;
+      grid-template-areas:
+        ". up ."
+        "left . right"
+        ". down ."
+        "confirm confirm confirm";
+      border-radius:10px; z-index:10;
     }
     #atkOverlay button {
       background:#a22;
       color:#fff !important;
       border:none !important;
+      font-size:36px;
+      width:70px; height:70px;
     }
+    #atkOverlay .up    { grid-area: up; }
+    #atkOverlay .down  { grid-area: down; }
+    #atkOverlay .left  { grid-area: left; }
+    #atkOverlay .right { grid-area: right; }
     #atkOverlay .confirm {
       background:#2a2;
       color:#fff !important;
       border:none !important;
-      flex:1 1 100%;
+      grid-area: confirm;
+      height:40px;
     }
 
     .sel {
-      outline:2px solid #ff0;
+      outline:3px solid #ff0;
     }
 
     /* Результат */

--- a/js/core.js
+++ b/js/core.js
@@ -230,14 +230,22 @@ function startNewRound() {
   }
 
   function openAttack(P) {
-    atkOv.innerHTML = ''; atkOv.style.visibility = 'visible';
+    atkOv.innerHTML = '';
+    atkOv.style.visibility = 'visible';
     let tmp = [];
-    Object.keys(DXY).filter(d => !usedMove[P].has(d)).forEach(d => {
+    ['up', 'left', 'right', 'down'].forEach(d => {
+      if (usedMove[P].has(d)) return;
       const btn = document.createElement('button');
-      btn.textContent = { up: '↑', down: '↓', left: '←', right: '→' }[d];
+      btn.className = d;
+      btn.textContent = { up: '▲', down: '▼', left: '◀', right: '▶' }[d];
       btn.onclick = () => {
-        if (tmp.includes(d)) { tmp = tmp.filter(x => x !== d); btn.classList.remove('sel'); }
-        else { tmp.push(d); btn.classList.add('sel'); }
+        if (tmp.includes(d)) {
+          tmp = tmp.filter(x => x !== d);
+          btn.classList.remove('sel');
+        } else {
+          tmp.push(d);
+          btn.classList.add('sel');
+        }
       };
       atkOv.append(btn);
     });


### PR DESCRIPTION
## Summary
- enlarge and redesign `#atkOverlay` with a grid layout and arrow buttons
- show chosen directions using a persistent `.sel` outline
- update `openAttack` to add arrow buttons positioned around the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f153527308332a248e528f7c9af00