### PR TITLE
Fix Next button enable logic

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -515,7 +515,7 @@ function startNewRound() {
       if (a === 'shield' && usedShield[P] >= 1) b.disabled = true;
     });
     if (single && phase === 'planA') {
-      btnNext.disabled = plans[P].length === 0;
+      btnNext.disabled = plans[P].length !== STEPS;
     } else if (isOnline) {
       if (phase === 'execute') btnNext.disabled = false;
       else btnNext.disabled = plans[P].length !== STEPS;


### PR DESCRIPTION
## Summary
- update `updateUI()` so the Next button only enables once all moves are planned in single-player planA phase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa47729848332b44ec1582b3e64f7