### PR TITLE
Update server port configuration

### DIFF
--- a/server.js
+++ b/server.js
@@ -225,10 +225,11 @@ function attachWebSocketServer(server) {
 }
 
 if (require.main === module) {
+  const port = process.env.PORT || 8080;
   const server = http.createServer(requestHandler);
   attachWebSocketServer(server);
-  server.listen(8080, () => {
-    console.log('Server running on http://localhost:8080');
+  server.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- add `port` constant to take environment or default to 8080
- pass `port` to `server.listen()`
- log message uses the configured port

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbf33269083329c05f00e5ec6fd3e