### PR TITLE
Add native share option for replay video

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -822,14 +822,28 @@ function startNewRound() {
     recordedChunks = [];
     recorder = new MediaRecorder(stream);
     recorder.ondataavailable = e => recordedChunks.push(e.data);
-    recorder.onstop = () => {
+    recorder.onstop = async () => {
       const blob = new Blob(recordedChunks, { type: 'video/webm' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'replay.webm';
-      a.click();
-      URL.revokeObjectURL(url);
+      const file = new File([blob], 'replay.webm', { type: 'video/webm' });
+      if (navigator.canShare && navigator.share && navigator.canShare({ files: [file] })) {
+        try {
+          await navigator.share({ files: [file] });
+        } catch (e) {
+          const url = URL.createObjectURL(file);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'replay.webm';
+          a.click();
+          URL.revokeObjectURL(url);
+        }
+      } else {
+        const url = URL.createObjectURL(file);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'replay.webm';
+        a.click();
+        URL.revokeObjectURL(url);
+      }
       recordedChunks = [];
     };
     recorder.start();


### PR DESCRIPTION
## Summary
- allow saving replay video using Web Share API when available

## Testing
- `npm test` *(fails: Playwright host validation warning, missing libraries)*

------
https://chatgpt.com/codex/tasks/task_e_685fc472c6a883329cadb966bf2fdb41