### PR TITLE
Fix scoreboard overlap on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,6 +532,9 @@
         flex-direction:column;
       }
     }
+    @media (max-width: 480px) {
+      #board { margin-top:60px; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- bump board down on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc600e92c83328988e68a4ac5fdac