### PR TITLE
Add replay save speed modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,6 +410,18 @@
       border:none !important;
     }
 
+    #speedModal {
+      position:absolute; top:50%; left:50%;
+      transform:translate(-50%,-50%);
+      background:#333; padding:20px;
+      border-radius:6px; text-align:center;
+      z-index:30;
+    }
+    #speedModal button {
+      margin:4px; padding:8px 12px;
+      color:#fff !important; border:none !important;
+    }
+
     /* Счёт */
     #scoreboard {
       position:absolute; top:6px; left:50%; transform:translateX(-50%);

--- a/js/core.js
+++ b/js/core.js
@@ -950,6 +950,29 @@ function startNewRound() {
     if (btn) btn.style.display = replayHistory.length ? 'inline-block' : 'none';
   }
 
+  function showSaveSpeedModal() {
+    if (document.getElementById('speedModal')) return;
+    const ov = document.createElement('div');
+    ov.id = 'speedModal';
+    ov.innerHTML =
+      '<div style="margin-bottom:8px;">Select speed</div>' +
+      '<div style="display:flex;gap:8px;justify-content:center;">' +
+      '<button data-speed="1">1x</button>' +
+      '<button data-speed="2">2x</button>' +
+      '<button data-speed="3">3x</button>' +
+      '<button data-speed="4">4x</button>' +
+      '<button data-speed="5">5x</button>' +
+      '</div>';
+    document.body.append(ov);
+    ov.querySelectorAll('button').forEach(btn => {
+      btn.onclick = () => {
+        replaySpeed = parseFloat(btn.dataset.speed);
+        ov.remove();
+        saveReplayVideo();
+      };
+    });
+  }
+
   function showResult(text) {
     const ov = document.createElement('div');
     ov.id = 'resultOverlay';
@@ -1092,7 +1115,7 @@ document.addEventListener('DOMContentLoaded', () => {
     replayBtn.onclick = () => startReplay();
     updateReplayButton();
   }
-  if (saveReplayBtn) saveReplayBtn.onclick = () => saveReplayVideo();
+  if (saveReplayBtn) saveReplayBtn.onclick = () => showSaveSpeedModal();
   if (replaySeek) replaySeek.oninput = () => seekReplay(parseInt(replaySeek.value));
   if (speedBtns.length) {
     speedBtns.forEach(btn => {

--- a/save-speed-modal.test.js
+++ b/save-speed-modal.test.js
@@ -1,0 +1,44 @@
+const { test } = require('node:test');
+const assert = require('assert');
+const { chromium } = require('playwright');
+const { spawn } = require('child_process');
+
+// Verify that clicking Save opens a modal to choose speed
+// and selecting a speed updates replaySpeed and calls saveReplayVideo.
+
+test('save replay speed modal sets speed', async () => {
+  const server = spawn('node', ['server.js'], { detached: true, stdio: 'ignore' });
+  await new Promise(r => setTimeout(r, 1000));
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:8080/?ws=ws://localhost:8080');
+
+  // provide a dummy replay and stub saveReplayVideo
+  await page.evaluate(() => {
+    const frames = Array.from({ length: 2 }, () => cloneState());
+    replayHistory = [{ actions: { A: [], B: [] }, states: frames }];
+    updateReplayButton();
+    window._saveCalled = false;
+    window.saveReplayVideo = () => { window._saveCalled = true; };
+  });
+
+  await page.click('#replayBtn');
+  await page.waitForSelector('#replayOverlay.show');
+
+  await page.click('#saveReplay');
+  await page.waitForSelector('#speedModal');
+
+  await page.click('#speedModal button[data-speed="3"]');
+
+  const speed = await page.evaluate(() => replaySpeed);
+  const called = await page.evaluate(() => window._saveCalled);
+  const modalGone = await page.evaluate(() => !document.getElementById('speedModal'));
+
+  assert.equal(speed, 3);
+  assert.ok(called);
+  assert.ok(modalGone);
+
+  await browser.close();
+  process.kill(-server.pid);
+});


### PR DESCRIPTION
## Summary
- add speed selection modal for replay export
- open modal from Save button
- add test for speed modal

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd509f04833297d8a1785fd0d0e1