### PR TITLE
Reduce replay pause button padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,6 +377,8 @@
     #replayPause {
       left:10px;
       right:auto;
+      padding:4px 6px;
+      width:auto;
     }
     .speedBtn.active {
       background:#0ff;


### PR DESCRIPTION
## Summary
- shrink `#replayPause` button so it looks compact

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_685fdef7e21c8332910a6273b61fb4dc