### PR TITLE
Update default WebSocket host

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ A simple WebSocket-based 5×5 PvP game.
 
 ### Configuring the WebSocket server
 
-The client connects to the hosted WebSocket server above by default. For local
-development you can point the client at your own server in two ways:
+The client connects to the hosted WebSocket server above by default (wss://zippy-scintillating-asp.glitch.me). For local development you can point the client at your own server in two ways:
 
 1. Define `WS_SERVER_URL` before including `js/socket.js`:
 

--- a/js/socket.js
+++ b/js/socket.js
@@ -9,7 +9,7 @@ let intentionalClose = false;
 // Connect to the dedicated WebSocket server by default. The URL can be
 // overridden by setting `window.WS_SERVER_URL` before this script runs or by
 // providing a `ws` query parameter in the page URL.
-let WS_SERVER_URL = 'wss://boom-poised-sawfish.glitch.me';
+let WS_SERVER_URL = 'wss://zippy-scintillating-asp.glitch.me';
 if (typeof window !== 'undefined') {
   const params = new URLSearchParams(window.location.search);
   if (window.WS_SERVER_URL) {

--- a/server-info.txt
+++ b/server-info.txt
@@ -1,2 +1,2 @@
-Current server link: https://boom-poised-sawfish.glitch.me
+Current server link: https://zippy-scintillating-asp.glitch.me
 The index file (index.html) must be placed in the root folder.


### PR DESCRIPTION
## Summary
- point client WebSocket code at `wss://zippy-scintillating-asp.glitch.me`
- update docs with the new server URL

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fecd3233c8332b0dce881c41096e5