### PR TITLE
Fix undefined updateReplayButton

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -950,6 +950,8 @@ function startNewRound() {
     if (btn) btn.style.display = replayHistory.length ? 'inline-block' : 'none';
   }
 
+  window.updateReplayButton = updateReplayButton;
+
   function showSaveSpeedModal() {
     if (document.getElementById('speedModal')) return;
     const ov = document.createElement('div');


### PR DESCRIPTION
## Summary
- export `updateReplayButton` so DOM listeners and tests can access it

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68604adcd0488332b1b7298ab576913f