### PR TITLE
Fix translations and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="apple-touch-icon" sizes="512x512" href="assets/icon.png"/>
   <link rel="manifest" href="manifest.json"/>
   <meta name="theme-color" content="#000000"/>
-<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Manrope:wght@400;700&family=Roboto+Mono:wght@400;700&family=PT+Sans:wght@400;700&family=Fira+Sans:wght@400;700&family=Orbitron:wght@400;700&family=Russo+One&display=swap&subset=cyrillic" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Manrope:wght@400;700&family=Roboto+Mono:wght@400;700&family=PT+Sans:wght@400;700&family=Fira+Sans:wght@400;700&family=Orbitron:wght@400;700&family=Russo+One&display=swap&subset=cyrillic,latin" rel="stylesheet">
   <style>
     * { box-sizing:border-box; margin:0; padding:0; }
     html,body {

--- a/js/core.js
+++ b/js/core.js
@@ -672,7 +672,7 @@ function startNewRound() {
         sendState(JSON.stringify({ units, round, step }));
       }
       round++;
-      if (round > MAX_R) { showResult('Изнурённые — ничья.'); return; }
+      if (round > MAX_R) { showResult(t('exhaustedDraw')); return; }
       phase = 'planA'; step = 1;
       edgesCollapsed = false;
       plans = { A: [], B: [] };
@@ -713,8 +713,9 @@ function startNewRound() {
     else if (!units.A.alive && units.B.alive) win = 'B';
     else if (step > STEPS && round >= MAX_R) win = 'DRAW';
     if (sim || win) {
-      const txt = sim ? 'Смерть с обеих сторон: ничья.' :
-        win === 'DRAW' ? 'Изнурённые — ничья.' : `Игрок ${win} победил!`;
+      const txt = sim ? t('bothDieDraw') :
+        win === 'DRAW' ? t('exhaustedDraw') :
+        (win === 'A' ? t('playerA_wins') : t('playerB_wins'));
       if (win === 'A' || win === 'B') { score[win]++; updateScore(); playSound('win'); }
       finalizeRound();
       showResult(txt); return true;
@@ -848,9 +849,9 @@ function startNewRound() {
       stream = document.body.captureStream();
     } else if (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia) {
       try { stream = await navigator.mediaDevices.getDisplayMedia({ video: true }); }
-      catch (e) { alert('Recording not supported'); return; }
+      catch (e) { alert(t('recordingNotSupported')); return; }
     } else {
-      alert('Recording not supported');
+      alert(t('recordingNotSupported'));
       return;
     }
     recordedChunks = [];
@@ -957,7 +958,7 @@ function startNewRound() {
     const ov = document.createElement('div');
     ov.id = 'speedModal';
     ov.innerHTML =
-      '<div style="margin-bottom:8px;">Select speed</div>' +
+      `<div style="margin-bottom:8px;">${t('selectSpeed')}</div>` +
       '<div style="display:flex;gap:8px;justify-content:center;">' +
       '<button data-speed="1">1x</button>' +
       '<button data-speed="2">2x</button>' +

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -52,6 +52,12 @@
       state_ok: 'Moves match',
       state_mismatch: 'State mismatch',
       room_closed_inactivity: 'Room closed due to inactivity'
+      ,bothDieDraw: 'Both players died: draw.'
+      ,exhaustedDraw: 'Exhausted \u2014 draw.'
+      ,playerA_wins: 'Player A won!'
+      ,playerB_wins: 'Player B won!'
+      ,selectSpeed: 'Select speed'
+      ,recordingNotSupported: 'Recording not supported'
       ,rulesHeader: 'Game Concept and Rules'
       ,rulesGeneral: 'Overview'
       ,rulesIntro: 'This is a turn-based 5\u00d75 PvP arena for two players. Up to three rounds are played. If nobody wins, sudden death starts on the central 3\u00d73 grid.'
@@ -120,6 +126,12 @@
       state_ok: 'Ходы совпадают',
       state_mismatch: 'Несовпадение состояний',
       room_closed_inactivity: 'Комната закрыта из-за неактивности',
+      bothDieDraw: 'Смерть с обеих сторон: ничья.',
+      exhaustedDraw: 'Изнурённые \u2014 ничья.',
+      playerA_wins: 'Игрок A победил!',
+      playerB_wins: 'Игрок B победил!',
+      selectSpeed: 'Выберите скорость',
+      recordingNotSupported: 'Запись не поддерживается',
       rulesHeader: 'Концепция и правила игры',
       rulesGeneral: 'Общее',
       rulesIntro: 'Это пошаговая PvP-арена 5\u00d75 для двух игроков. Игра идёт три раунда, затем в отсутствие победителя начинается \u00abвнезапная смерть\u00bb в центре 3\u00d73.',
@@ -188,6 +200,12 @@
       state_ok: 'Ходи збігаються',
       state_mismatch: 'Неспівпадіння станів',
       room_closed_inactivity: 'Кімната закрита через неактивність',
+      bothDieDraw: 'Смерть обох гравців: нічия.',
+      exhaustedDraw: 'Виснаження \u2014 нічия.',
+      playerA_wins: 'Гравець A переміг!',
+      playerB_wins: 'Гравець B переміг!',
+      selectSpeed: 'Виберіть швидкість',
+      recordingNotSupported: 'Запис не підтримується',
       rulesHeader: 'Концепція та правила гри',
       rulesGeneral: 'Загальне',
       rulesIntro: 'Це покрокова PvP-арена 5\u00d75 для двох гравців. Після трьох раундів за відсутності переможця починається \u00abраптова смерть\u00bb у центрі 3\u00d73.',


### PR DESCRIPTION
## Summary
- update font link to include latin subset
- add missing translation keys in all languages
- use translations for result messages and recording alerts

## Testing
- `npm test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861669c45ec83328de94acfe4e2cc34