### PR TITLE
Allow custom P2P signaling server

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ answers and ICE candidates. The first peer in the room creates the offer and the
 second responds. To close the connection call `disconnectPeer()` which cleans up
 both the WebRTC channel and the WebSocket. See `p2p-server-info.txt` for the
 message format.
+
+You can point the client at a different signaling server in the same way as the
+main WebSocket connection: either define `SIGNAL_SERVER_URL` before loading
+`js/p2p.js` or supply a `signal` query parameter in the page URL.

--- a/js/p2p.js
+++ b/js/p2p.js
@@ -1,7 +1,15 @@
 // WebRTC P2P connection logic using SimplePeer
 // Connects to signaling server and exchanges signaling data via WebSocket
 
-const SIGNAL_SERVER_URL = 'wss://hypnotic-brassy-forest.glitch.me';
+let SIGNAL_SERVER_URL = 'wss://hypnotic-brassy-forest.glitch.me';
+if (typeof window !== 'undefined') {
+  const params = new URLSearchParams(window.location.search);
+  if (window.SIGNAL_SERVER_URL) {
+    SIGNAL_SERVER_URL = window.SIGNAL_SERVER_URL;
+  } else if (params.get('signal')) {
+    SIGNAL_SERVER_URL = params.get('signal');
+  }
+}
 let signalSocket;
 let peer;
 let currentRoom;


### PR DESCRIPTION
## Summary
- make P2P signaling server configurable via `SIGNAL_SERVER_URL` or `signal` query parameter
- document how to override the signaling server

## Testing
- `npm test` *(fails: kill ESRCH)*

------
https://chatgpt.com/codex/tasks/task_e_68630371cfc0833298da6e9ab72cc377