### PR TITLE
Fix deleting moves after full plan and edge collapse bug

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -316,7 +316,7 @@ function startNewRound() {
   }
 
   function deleteLast() {
-    const P = isOnline ? mySide() : (plans.A.length === STEPS && plans.B.length < STEPS ? 'B' : 'A');
+    const P = isOnline ? mySide() : (phase === 'planA' ? 'A' : 'B');
     if (!plans[P].length) return;
     const a = plans[P].pop();
     if (typeof a === 'string') {
@@ -688,7 +688,6 @@ function startNewRound() {
       round++;
       if (round > MAX_R) { showResult(t('exhaustedDraw')); return; }
       phase = 'planA'; step = 1;
-      edgesCollapsed = false;
       plans = { A: [], B: [] };
       window.plans = plans;
       usedMove = { A: new Set(), B: new Set() };


### PR DESCRIPTION
## Summary
- let players delete actions even when the plan is full
- keep board edges collapsed after the collapse round

## Testing
- `npm test` *(fails: testCodeFailure ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68756dc433c0833283f56e09a718a61c