### PR TITLE
Improve layout scaling, onboarding, and replay exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1593,6 +1593,33 @@
       flex-direction:column;
       gap:12px;
     }
+    #tutorialPrompt .tutorialPromptLanguage {
+      display:flex;
+      flex-direction:column;
+      gap:8px;
+      text-align:left;
+    }
+    #tutorialPrompt .tutorialPromptLanguage label {
+      font-weight:600;
+      font-size:15px;
+      color:var(--color-heading);
+    }
+    #tutorialPrompt .tutorialPromptLanguage select {
+      appearance:none;
+      background:var(--color-input-bg);
+      border:1px solid var(--color-input-border);
+      border-radius:12px;
+      padding:10px 14px;
+      color:var(--color-text-primary);
+      font-size:15px;
+      font-weight:500;
+      outline:none;
+      transition:border-color .2s ease, box-shadow .2s ease;
+    }
+    #tutorialPrompt .tutorialPromptLanguage select:focus {
+      border-color:var(--color-accent);
+      box-shadow:0 0 0 3px rgba(56,189,248,0.25);
+    }
     #tutorialPrompt button.secondary {
       background:transparent;
       color:var(--color-accent);
@@ -2422,6 +2449,14 @@
     <div class="tutorialPromptCard">
       <h2 id="tutorialPromptTitle" data-i18n="tutorialPromptTitle">Learn the basics?</h2>
       <p id="tutorialPromptBody" data-i18n="tutorialPromptBody">Would you like to run the guided tutorial or skip it for now?</p>
+      <div class="tutorialPromptLanguage">
+        <label for="tutorialPromptLang" data-i18n="tutorialPromptLanguage">Language</label>
+        <select id="tutorialPromptLang">
+          <option value="en">English</option>
+          <option value="ru">Русский</option>
+          <option value="uk">Українська</option>
+        </select>
+      </div>
       <div class="tutorialPromptButtons">
         <button id="tutorialPromptStart" class="primary" data-i18n="tutorialPromptStart" data-sound="nav">Start tutorial</button>
         <button id="tutorialPromptSkip" class="secondary" data-i18n="tutorialPromptSkip" data-sound="nav">Skip for now</button>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -157,6 +157,7 @@
       ,tutorialPromptStart: 'Yes, teach me'
       ,tutorialPromptSkip: 'Not now'
       ,tutorialPromptNote: 'You can launch the tutorial later from the Rules menu.'
+      ,tutorialPromptLanguage: 'Language'
     },
     ru: {
       singlePlayer: '1 игрок',
@@ -312,6 +313,7 @@
       ,tutorialPromptStart: '\u0416\u0435\u043b\u0430\u044e'
       ,tutorialPromptSkip: '\u041d\u0435\u0442'
       ,tutorialPromptNote: '\u041f\u043e\u0437\u0436\u0435 \u043e\u0431\u0443\u0447\u0435\u043d\u0438\u0435 \u043c\u043e\u0436\u043d\u043e \u043e\u0442\u043a\u0440\u044b\u0442\u044c \u0432 \u0440\u0430\u0437\u0434\u0435\u043b\u0435 \u00ab\u041f\u0440\u0430\u0432\u0438\u043b\u0430\u00bb.'
+      ,tutorialPromptLanguage: '\u042f\u0437\u044b\u043a \u0438\u043d\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0430'
     },
     uk: {
       singlePlayer: '1 гравець',
@@ -467,6 +469,7 @@
       ,tutorialPromptStart: '\u0411\u0430\u0436\u0430\u044e'
       ,tutorialPromptSkip: '\u041d\u0456'
       ,tutorialPromptNote: '\u041f\u043e\u0432\u0435\u0440\u043d\u0443\u0442\u0438\u0441\u044c \u0434\u043e \u043d\u0430\u0432\u0447\u0430\u043d\u043d\u044f \u043c\u043e\u0436\u043d\u0430 \u0437\u0433\u043e\u0434\u043e\u043c \u0447\u0435\u0440\u0435\u0437 \u043c\u0435\u043d\u044e \u00ab\u041f\u0440\u0430\u0432\u0438\u043b\u0430\u00bb.'
+      ,tutorialPromptLanguage: '\u041c\u043e\u0432\u0430 \u0456\u043d\u0442\u0435\u0440\u0444\u0435\u0439\u0441\u0443'
     }
   };
 


### PR DESCRIPTION
## Summary
- allow the HUD layout to scale further on small viewports and enable scrolling if required so desktop players can reach the action buttons
- let first-time players choose their language from the tutorial prompt and keep the dropdown in sync with the settings modal
- redraw saved replay frames with attack and shield effects, refined board styling, and a longer capture window for complete recordings

## Testing
- npm test *(fails: missing Playwright system dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6906372f510c8332aec79babeefe4ea2